### PR TITLE
Guess uri based on entryname; Make default gpg binary path more sensible

### DIFF
--- a/pass2bw.py
+++ b/pass2bw.py
@@ -98,7 +98,7 @@ def main():
 
     parser.add_argument('--directory', '-d', default='~/.password-store',
                         help='Directory of the password store.')
-    parser.add_argument('--gpg-binary', '-b', dest='binary', default='/usr/local/bin/gpg',
+    parser.add_argument('--gpg-binary', '-b', dest='binary', default='/usr/bin/gpg',
                         help='Path to the GPG binary.')
     parser.add_argument('--output-file', '-o', dest='output', default='pass.csv',
                         help='File to write the CSV in.')

--- a/pass2bw.py
+++ b/pass2bw.py
@@ -12,6 +12,8 @@ try:
 except ImportError:
     from defaults import CSV_FIELDS, FIELD_DEFAULTS, FIELD_FUNCTIONS, FIELD_PATTERNS
 
+DOMAIN_REGEX_RAW = "^((?!-)[A-Za-z0-9-]" + "{1,63}(?<!-)\\.)" + "+[A-Za-z]{2,6}"
+DOMAIN_REGEX = re.compile(DOMAIN_REGEX_RAW)
 
 def traverse(directory):
     pass_files = []
@@ -48,6 +50,12 @@ def decrypt(files, binary, agent):
 
     return datas
 
+def _guess_uri(row):
+    if not 'login_uri' in row:
+        return ''
+    if re.search(DOMAIN_REGEX, row["name"]):
+        return row["name"]
+    return ''
 
 def parse(base_dir, files):
     parsed = []
@@ -68,6 +76,8 @@ def parse(base_dir, files):
             else:
                 row[field] = ''
 
+        if row['login_uri'] == '':
+            row['login_uri'] = _guess_uri(row)
         parsed.append(row)
 
     return parsed


### PR DESCRIPTION
* Guess uri based on name if possible

many pass users name their entries according to the domain/website the
entry is for. Common browser-extensions allow matching uri against entry
name. So, for this exporter, it makes sense to mimic this regarding
output login_url …

* Use more sensible gpg path default